### PR TITLE
feat(core): add ./vite export for programmatic Vite config access

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,10 @@
       "types": "./dist/node.d.mts",
       "default": "./dist/node.mjs"
     },
+    "./vite": {
+      "types": "./dist/vite/index.d.mts",
+      "default": "./dist/vite/index.mjs"
+    },
     "./jsx-runtime": {
       "types": "./dist/jsx-runtime.d.mts",
       "default": "./dist/jsx-runtime.mjs"

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/node.ts', 'src/jsx-runtime.ts', 'src/cli/bin.ts'],
+  entry: ['src/index.ts', 'src/node.ts', 'src/vite/index.ts', 'src/jsx-runtime.ts', 'src/cli/bin.ts'],
   format: 'esm',
   dts: true,
   clean: true,


### PR DESCRIPTION
Expose viteConfigFor and resolveConfig through a dedicated ./vite export subpath, allowing external tools (e.g. tai-office portal) to programmatically create Vite InlineConfig without importing from internal paths.

Changes:
- package.json: add "./vite" entry to exports map
- tsdown.config.ts: add src/vite/index.ts as a build entry

---
您好, 感謝你和其他兩位熱心台灣開發者的熱血成果. 
我正在 vibe  一個集成三個作品的入口, 核心仍依賴於你們三位的成果.
這個集成入口需要您將部分資訊 export 出來我方能整合, 故提交這個 PR.

專案如下, 也期待您給予意見回饋. 感謝.
https://github.com/kywk/tai-office