### PR TITLE
fix: make Windows test and Vite SSR paths work reliably

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ If [open-slide](https://github.com/1weiho/open-slide) is Google Slides for agent
 npx @open-sheet/cli init my-sheets
 ```
 
+> Practice exercise note: this change is only for local Git workflow practice.
+
 ## Why
 
 Agents write excellent analysis and terrible spreadsheets, and the reason is specific: **`=SUM(B2:B13)`**.

--- a/packages/cli/src/package-contents.test.ts
+++ b/packages/cli/src/package-contents.test.ts
@@ -14,13 +14,15 @@ function pack(name: string): { files: string[]; manifest: Record<string, any> } 
     cwd: join(packages, name),
     stdio: 'pipe',
     timeout: 120_000,
+    shell: process.platform === 'win32',
   })
   const tarball = join(out, readdirSync(out).find((file) => file.endsWith('.tgz')) as string)
 
   const files = execFileSync('tar', ['tzf', tarball], { encoding: 'utf8' })
+    .replace(/\r\n/g, '\n')
     .split('\n')
     .filter(Boolean)
-    .map((path) => path.replace(/^package\//, ''))
+    .map((path) => path.replace(/^package\//, '').replace(/\r$/, ''))
 
   const manifest = JSON.parse(
     execFileSync('tar', ['xzOf', tarball, 'package/package.json'], { encoding: 'utf8' }),

--- a/packages/core/e2e/published.test.ts
+++ b/packages/core/e2e/published.test.ts
@@ -48,7 +48,13 @@ describe.skipIf(!BROWSER)('a published install renders', () => {
 
   it('scaffolds, installs from tarballs, and paints the grid', { timeout: 600_000 }, async () => {
     const run = (cmd: string, args: string[], cwd: string) =>
-      execFileSync(cmd, args, { cwd, stdio: 'pipe', timeout: 240_000, encoding: 'utf8' })
+      execFileSync(cmd, args, {
+        cwd,
+        stdio: 'pipe',
+        timeout: 240_000,
+        encoding: 'utf8',
+        shell: process.platform === 'win32',
+      })
 
     for (const pkg of ['core', 'cli']) {
       run('pnpm', ['pack', '--pack-destination', scratch], join(repo, 'packages', pkg))

--- a/packages/core/src/cli/load.ts
+++ b/packages/core/src/cli/load.ts
@@ -1,4 +1,5 @@
 import { createServer, type ViteDevServer } from 'vite'
+import { resolveConfig, viteConfigFor } from '../vite/index.js'
 import type { DesignSystem } from '../style/design.js'
 
 export interface WorkbookModule {
@@ -16,13 +17,14 @@ export async function createLoader(root: string): Promise<{
   load: (file: string) => Promise<WorkbookModule>
   close: () => Promise<void>
 }> {
+  const config = resolveConfig(root, {})
   const server: ViteDevServer = await createServer({
+    ...viteConfigFor(config),
     root,
     configFile: false,
     server: { middlewareMode: true },
     appType: 'custom',
     logLevel: 'warn',
-    esbuild: { jsx: 'automatic', jsxImportSource: '@open-sheet/core' },
   })
 
   return {

--- a/packages/core/src/skills.test.ts
+++ b/packages/core/src/skills.test.ts
@@ -6,10 +6,10 @@ import { describe, expect, it } from 'vitest'
 const skills = join(dirname(fileURLToPath(import.meta.url)), '..', 'skills')
 
 function frontmatter(markdown: string): Record<string, string> {
-  const match = /^---\n([\s\S]*?)\n---/.exec(markdown)
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(markdown)
   if (!match) return {}
   const out: Record<string, string> = {}
-  for (const line of (match[1] as string).split('\n')) {
+  for (const line of (match[1] as string).split(/\r?\n/)) {
     const at = line.indexOf(':')
     if (at > 0) out[line.slice(0, at).trim()] = line.slice(at + 1).trim()
   }

--- a/packages/core/src/vite/app-plugin.ts
+++ b/packages/core/src/vite/app-plugin.ts
@@ -41,6 +41,8 @@ export function appEntry(): string {
 }
 
 function shell(entry: string): string {
+  const normalized = entry.replace(/\\/g, '/')
+  const src = normalized.startsWith('/') ? `/@fs${normalized}` : `/@fs/${normalized}`
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -50,7 +52,7 @@ function shell(entry: string): string {
 </head>
 <body>
 <div id="root"></div>
-<script type="module" src="/@fs${entry}"></script>
+<script type="module" src="${src}"></script>
 </body>
 </html>
 `

--- a/packages/core/src/vite/index.ts
+++ b/packages/core/src/vite/index.ts
@@ -1,5 +1,6 @@
-import { realpathSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
 import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
 import react from '@vitejs/plugin-react'
 import type { InlineConfig, PluginOption } from 'vite'
 import { apiPlugin } from './api-plugin.js'
@@ -43,13 +44,26 @@ function reactAliases(): { find: RegExp; replacement: string }[] {
   return out
 }
 
+function esmEntry(specifier: string): string {
+  const pkgPath = require.resolve(`${specifier}/package.json`)
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+    exports?: { '.': { import?: { default?: string }; default?: string } }
+    module?: string
+    main?: string
+  }
+  const candidate =
+    pkg.exports?.['.']?.import?.default ?? pkg.exports?.['.']?.default ?? pkg.module ?? pkg.main
+  if (!candidate) return require.resolve(specifier)
+  return resolve(dirname(pkgPath), candidate)
+}
+
 function commonJsAliases(): { find: RegExp; replacement: string }[] {
   const out: { find: RegExp; replacement: string }[] = []
   for (const specifier of COMMONJS_SPECIFIERS) {
     try {
       out.push({
         find: new RegExp(`^${specifier.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}$`),
-        replacement: require.resolve(specifier),
+        replacement: esmEntry(specifier),
       })
     } catch {
       // leave it to the workspace; a clear resolve error beats a wrong alias

--- a/packages/core/src/vite/index.ts
+++ b/packages/core/src/vite/index.ts
@@ -19,6 +19,8 @@ const REACT_SPECIFIERS = [
   'react',
 ] as const
 
+const COMMONJS_SPECIFIERS = ['@formulajs/formulajs'] as const
+
 /**
  * The viewer ships inside this package, so its React must resolve from here —
  * the user's workspace has no reason to depend on React to author a spreadsheet.
@@ -29,6 +31,21 @@ const REACT_SPECIFIERS = [
 function reactAliases(): { find: RegExp; replacement: string }[] {
   const out: { find: RegExp; replacement: string }[] = []
   for (const specifier of REACT_SPECIFIERS) {
+    try {
+      out.push({
+        find: new RegExp(`^${specifier.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}$`),
+        replacement: require.resolve(specifier),
+      })
+    } catch {
+      // leave it to the workspace; a clear resolve error beats a wrong alias
+    }
+  }
+  return out
+}
+
+function commonJsAliases(): { find: RegExp; replacement: string }[] {
+  const out: { find: RegExp; replacement: string }[] = []
+  for (const specifier of COMMONJS_SPECIFIERS) {
     try {
       out.push({
         find: new RegExp(`^${specifier.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}$`),
@@ -96,7 +113,7 @@ export function viteConfigFor(
     appType: 'custom',
     plugins: openSheetPlugins(config, mcp === true),
     resolve: {
-      alias: [...coreAliases(), ...reactAliases()],
+      alias: [...coreAliases(), ...reactAliases(), ...commonJsAliases()],
       dedupe: ['react', 'react-dom'],
     },
     optimizeDeps: {
@@ -105,7 +122,7 @@ export function viteConfigFor(
       // discovered — or excluded, as React was — the browser receives raw
       // CommonJS, the named import fails, and the viewer dies before it mounts
       // with nothing on screen but a console error.
-      include: [...REACT_SPECIFIERS, '@formulajs/formulajs'],
+      include: [...REACT_SPECIFIERS, ...COMMONJS_SPECIFIERS],
       // Already ESM, and aliased to a real path — but more importantly it
       // reaches Node-only code (the optional `import('playwright')` behind PDF
       // export) that the dep optimizer cannot analyse and refuses to bundle.

--- a/packages/core/src/vite/jsx-plugin.ts
+++ b/packages/core/src/vite/jsx-plugin.ts
@@ -10,17 +10,22 @@ const PRAGMA = '/** @jsxImportSource @open-sheet/core */\n'
  * already moved once, from esbuild to oxc — this injects the standard pragma,
  * which every JSX transform honours.
  */
+function normalize(path: string): string {
+  return path.replace(/\\/g, '/')
+}
+
 export function jsxPlugin(config: ResolvedConfig): Plugin {
-  const sheets = join(config.root, config.sheetsDir)
-  const themes = join(config.root, config.themesDir)
+  const sheets = normalize(join(config.root, config.sheetsDir))
+  const themes = normalize(join(config.root, config.themesDir))
 
   return {
     name: 'open-sheet:jsx',
     enforce: 'pre',
     transform(code, id) {
       const [path] = id.split('?')
-      if (!path?.endsWith('.tsx') && !path?.endsWith('.jsx')) return undefined
-      if (!path.startsWith(sheets) && !path.startsWith(themes)) return undefined
+      const normalized = path ? normalize(path) : undefined
+      if (!normalized?.endsWith('.tsx') && !normalized?.endsWith('.jsx')) return undefined
+      if (!normalized.startsWith(sheets) && !normalized.startsWith(themes)) return undefined
       if (code.includes('@jsxImportSource')) return undefined
       return { code: PRAGMA + code, map: null }
     },


### PR DESCRIPTION
## Summary
This fixes Windows-specific issues that blocked validation and runtime workbook loading.

## Changes
- fix pnpm execution in package-content tests for Windows
- normalize CRLF parsing in skill metadata checks
- normalize Windows path separators before JSX pragma injection checks
- resolve CommonJS package entry points for Vite SSR evaluation
- align the workbook loader with the actual Vite config used by the dev server

## Verification
I validated this with:

```powershell
Set-Location 'd:/Mitchell Github/open-sheet'; corepack pnpm test -- --run

Result:

17 test files passed
1 skipped
186 tests passed
3 skipped